### PR TITLE
fix(useChains): fix missing endpoints & chain name crash

### DIFF
--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -129,6 +129,7 @@ export class WalletManager extends StateBase {
         this.isLazy,
         this.logger
       );
+
       return converted;
     });
 
@@ -142,10 +143,17 @@ export class WalletManager extends StateBase {
     });
 
     this.chainRecords.forEach((chainRecord, index) => {
-      const repo = new WalletRepo(
-        chainRecord,
-        wallets.map(({ getChainWallet }) => getChainWallet(chainRecord.name)!)
+      const chainWallets = wallets.map(
+        ({ getChainWallet }) => getChainWallet(chainRecord.name)!
       );
+
+      const repo = new WalletRepo(
+        chainWallets.find(
+          (prev) => prev.chainName === chainRecord.name
+        ).chainRecord,
+        chainWallets
+      );
+
       repo.logger = this.logger;
       repo.repelWallet = this.repelWallet;
       repo.session = this.session;
@@ -154,6 +162,7 @@ export class WalletManager extends StateBase {
         this.chainRecords[index] = repo.chainRecord;
       }
     });
+
     this.checkEndpoints(endpointOptions?.endpoints);
   }
 

--- a/packages/core/src/utils/convert.ts
+++ b/packages/core/src/utils/convert.ts
@@ -1,4 +1,5 @@
 import { AssetList, Chain } from '@chain-registry/types';
+import { chains } from 'chain-registry';
 
 import { ChainName, ChainRecord, Endpoints, SignerOptions } from '../types';
 import { getIsLazy } from './endpoint';
@@ -26,7 +27,10 @@ export function convertChain(
   };
   const converted = {
     name: chainName,
-    chain: typeof chain === 'string' ? void 0 : chain,
+    chain:
+      typeof chain === 'string'
+        ? chains.find((prev) => prev.chain_name === chainName)
+        : chain,
     assetList,
     clientOptions: {
       stargate: signerOptions?.stargate?.(chain),

--- a/packages/react-lite/src/hooks/useChains.ts
+++ b/packages/react-lite/src/hooks/useChains.ts
@@ -20,8 +20,8 @@ export function useChains(chainNames: ChainName[], sync = true) {
     );
   }
 
-  const repos = names.map(name => walletManager.getWalletRepo(name));
-  const ids = repos.map(repo => repo.chainRecord.chain.chain_id);
+  const repos = names.map((name) => walletManager.getWalletRepo(name));
+  const ids = repos.map((repo) => repo.chainRecord.chain.chain_id);
 
   return names.reduce((result, chainName, index) => {
     const walletRepo = repos[index];
@@ -35,11 +35,11 @@ export function useChains(chainNames: ChainName[], sync = true) {
             await wallet.client?.enable?.(ids);
           } catch (e) {
             for (const repo of repos) {
-              await wallet.client?.addChain?.(repo.chainRecord)
+              await wallet.client?.addChain?.(repo.chainRecord);
             }
             await wallet.client?.enable?.(ids);
           }
-        }
+        };
       }
 
       if (wallet.isModeWalletConnect) {


### PR DESCRIPTION
### 🛠 Fix: `useChains` Hook Issues  

This PR fixes two issues related to the `useChains` hook in CosmosKit:  

1. **Community Chains RPC/REST Error**  
   - Fixed an issue where using `useChains` with community chains would throw an error due to missing RPC or REST API endpoints in `chainRecords.preferredEndpoints`.  
   - This bug **does not occur when running tests** but happens when running the `example-lite` project.  
   - Affected chains: `'ethereum'`, `'rootstock'`, `'solana'`, `'ton'`, `'tron'`, `'bluechip'`, `'lorenzo'`, `'neura'`, `'paloma'`, `'unicorn'`.  
   
2. **Crash When Using Chain Names in `ChainProvider`**  🔗 **Fixes**: #515  
   - Fixed an issue where passing only chain names (instead of full chain info) to `ChainProvider` caused a crash.  
   - This was due to `convertChain` returning `undefined` when receiving a chain name instead of a chain object, resulting in an empty `chain` in `chainRecord`.  
   - This fix ensures proper handling of chain names, preventing the crash.  