### PR TITLE
Typo fix chain-provider.mdx

### DIFF
--- a/packages/docs/pages/provider/chain-provider.mdx
+++ b/packages/docs/pages/provider/chain-provider.mdx
@@ -12,7 +12,7 @@ These properties are shared by `ChainProvider`s from `@cosmos-kit/react` and `@c
 
 Required property of type `(Chain | string)[]`.
 
-It defines supported chains. Any actions involving chains beyound it might cause errors.
+It defines supported chains. Any actions involving chains beyond it might cause errors.
 
 If chain has been registered in `@chain-registry/client`, you can also simply provide chain name (type `string`) here and it'll fetch the chain information automatically.
 


### PR DESCRIPTION
Corrected "beyound" to "beyond" for clarity and accuracy.