### PR TITLE
feat: add web3auth mfa level support

### DIFF
--- a/wallets/web3auth/src/extension/types.ts
+++ b/wallets/web3auth/src/extension/types.ts
@@ -4,6 +4,7 @@ import { Wallet } from '@cosmos-kit/core';
 import { Ecies } from '@toruslabs/eccrypto';
 import {
   LOGIN_PROVIDER_TYPE,
+  MfaLevelType,
   WEB3AUTH_NETWORK_TYPE,
 } from '@web3auth/auth-adapter';
 import { Web3AuthNoModalOptions } from '@web3auth/base';
@@ -19,6 +20,7 @@ export type Web3AuthLoginMethod = {
 
 export type Web3AuthClientOptions = {
   loginProvider: LOGIN_PROVIDER_TYPE;
+  mfaLevel?: MfaLevelType;
   getLoginHint?: () => string | undefined;
 
   // Web3Auth client options.

--- a/wallets/web3auth/src/extension/utils.ts
+++ b/wallets/web3auth/src/extension/utils.ts
@@ -157,9 +157,13 @@ export const connectClientAndProvider = async (
     );
   }
 
+  const mfaLevel = options.mfaLevel ?? 'default';
   const authAdapter = new AuthAdapter({
     adapterSettings: {
       uxMode,
+    },
+    loginSettings: {
+      mfaLevel,
     },
   });
   client.configureAdapter(authAdapter);


### PR DESCRIPTION
This PR adds support for configuring the Web3Auth MFA levels, as described in [1]

CC @pyramation @NoahSaso 

[1]: https://web3auth.io/docs/sdk/pnp/web/no-modal/mfa#loginsettings