### PR TITLE
fix: correct syntax issue with galaxystation in array

### DIFF
--- a/packages/cosmos-kit/src/wallets.ts
+++ b/packages/cosmos-kit/src/wallets.ts
@@ -211,5 +211,5 @@ export const wallets = createAllWalletList([
   ...tailwind,
   ...owallet,
   ...cdcwallet,
-  --- galaxystation,
+  ...galaxystation,
 ]);


### PR DESCRIPTION
This PR fixes a syntax error in the wallet array where an invalid decrement operator (--) was mistakenly included. The issue caused the module to fail parsing

### Changes Made
- Replaced the incorrect syntax (-- - galaxystation) with the correct array spread for galaxystation.
- Ensured the array includes all necessary wallet integrations correctly.

### Testing
- Verified that the module compiles without syntax errors.
- Confirmed functionality of wallet integrations.
