### PR TITLE
fix links

### DIFF
--- a/packages/docs/pages/provider/chain-provider.mdx
+++ b/packages/docs/pages/provider/chain-provider.mdx
@@ -263,7 +263,7 @@ There are four levels of `isLazy` setting.
 
 4. Parameter `isLazy`: `isLazy` in `getRpcEndpoint` and `getRestEndpoint` prarameters. It also globally controls all endpoints. (Note: this one only affects getting endpoint functions with the highest priority, but won't affect signing or broadcasting a transaction.)
 
-The calculation of final `isLazy` can be seen [here](https://github.com/hyperweb-io/cosmos-kit/blob/main/packages/core/src/utils/endpoint.ts#L32-L59).
+The calculation of final `isLazy` can be seen [here](https://github.com/hyperweb-io/cosmos-kit/blob/main/packages/core/src/utils/endpoint.ts#L105-L132).
 
 **`isLazy` Examples:**
 


### PR DESCRIPTION
The number of lines of code corresponding to the link in the original document is incorrect, and this PR changes it to be correct.