### PR TITLE
Remove unnecessary console logging

### DIFF
--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -100,7 +100,6 @@ export const ChainProvider = ({
   }
 
   logger.debug('Using default wallet modal.');
-  console.log('Using locally built cosmos kit');
 
   const defaultModal = useCallback(
     (props: WalletModalProps) => (


### PR DESCRIPTION
Removing one line on "locally built cosmos kit" that is spamming up the console. It looks like this was just a debugging message left in there but, if it's meant to signal something about the build, we can figure out how to properly wrap it.