### PR TITLE
bump cosmiframe to v1.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
     "@cosmjs/stargate": "^0.32.3",
-    "@dao-dao/cosmiframe": "^1.0.0-rc.1",
+    "@dao-dao/cosmiframe": "^1.0.0",
     "@walletconnect/types": "2.11.0",
     "bowser": "2.11.0",
     "cosmjs-types": "^0.9.0",

--- a/packages/react-lite/package.json
+++ b/packages/react-lite/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@chain-registry/types": "^0.46.11",
     "@cosmos-kit/core": "^2.16.1",
-    "@dao-dao/cosmiframe": "^1.0.0-rc.1"
+    "@dao-dao/cosmiframe": "^1.0.0"
   },
   "peerDependencies": {
     "@types/react": "latest",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,7 +75,7 @@
     ]
   },
   "devDependencies": {
-    "@dao-dao/cosmiframe": "^1.0.0-rc.1",
+    "@dao-dao/cosmiframe": "^1.0.0",
     "@types/react": "latest",
     "@types/react-dom": "latest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
     node-appwrite "^14.0.0"
     ses "^0.18.4"
 
-"@dao-dao/cosmiframe@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@dao-dao/cosmiframe/-/cosmiframe-1.0.0-rc.1.tgz#51d4d1801605b8abfd01ae0425c797b6b876991e"
-  integrity sha512-XftJPwbqgS1RWg9SUNBI58vTGnjINZ995OYRwDuUZ6CsuENS2DifAzqgzDgdac+0o5Hqvy/5Aq+HN1Jl/dptTw==
+"@dao-dao/cosmiframe@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dao-dao/cosmiframe/-/cosmiframe-1.0.0.tgz#c780a2c3f14560ccd0f178616567328ca0bc9fcf"
+  integrity sha512-xPaD9MV1tUueYl+VIJD7CEi4+MCdcgo4E1R9w8XplKlM7pvmBaSBeTz88HwITpKxWKI+DWoJngeCWu5/8oqLJQ==
   dependencies:
     uuid "^9.0.1"
 


### PR DESCRIPTION
nothing changed, just no need to stay on the release candidate version when v1.0.0 is published